### PR TITLE
refactor: replace ufo.joinURL with native URL API

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"svelte-meta-tags": "^4.4.0",
 		"typescript": "^5.8.3",
 		"typescript-svelte-plugin": "^0.3.49",
-		"ufo": "^1.6.1",
 		"unocss": "^66.4.1",
 		"unplugin-icons": "^22.2.0",
 		"vite": "^7.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       typescript-svelte-plugin:
         specifier: ^0.3.49
         version: 0.3.49(svelte@5.38.0)(typescript@5.8.3)
-      ufo:
-        specifier: ^1.6.1
-        version: 1.6.1
       unocss:
         specifier: ^66.4.1
         version: 66.4.1(postcss@8.5.6)(vite@7.0.6(@types/node@24.2.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.2)(yaml@2.8.0))

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -2,7 +2,6 @@
 	import { getUser } from '$lib/api.remote';
 	import { route } from '$lib/ROUTES';
 	import * as DarkMode from 'svelte-fancy-darkmode';
-	import { joinURL } from 'ufo';
 	import GitHub from '~icons/line-md/github-loop';
 	import MoonToSunny from '~icons/line-md/moon-filled-to-sunny-filled-loop-transition';
 
@@ -11,7 +10,7 @@
 	import Divider from './Divider.svelte';
 
 	const user = await getUser();
-	const userUrl = joinURL('https://github.com', user.username);
+	const userUrl = new URL(user.username, 'https://github.com/').toString();
 	const description = `${user.username}'s recent pull requests on GitHub`;
 </script>
 

--- a/src/routes/Meta.svelte
+++ b/src/routes/Meta.svelte
@@ -2,10 +2,9 @@
 	import { getUser } from '$lib/api.remote';
 	import { route } from '$lib/ROUTES';
 	import { MetaTags } from 'svelte-meta-tags';
-	import { joinURL } from 'ufo';
 
 	const user = await getUser();
-	const userUrl = joinURL('https://github.com', user.username);
+	const userUrl = new URL(user.username, 'https://github.com/').toString();
 	const title = `${user.name} is Contributing...`;
 	const description = `${user.username}'s recent pull requests on GitHub`;
 	const faviconURL = `${userUrl}.png`;

--- a/src/routes/PullRequest.svelte
+++ b/src/routes/PullRequest.svelte
@@ -1,13 +1,12 @@
 <script lang='ts'>
 	import type { PR } from '$lib/types.js';
 	import { formatTimeAgo } from '@vueuse/core';
-	import { joinURL } from 'ufo';
 
 	import PullRequestIcon from '~icons/ph/git-pull-request-duotone';
 
 	const { pr, count }: { pr: PR; count: number } = $props();
 
-	const prURL = joinURL('https://github.com', pr.repo);
+	const prURL = new URL(pr.repo, 'https://github.com/').toString();
 	const prUserName = pr.repo.split('/').at(0) ?? '';
 	const prRepoName = pr.repo.split('/').at(1) ?? '';
 </script>

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -6,7 +6,6 @@ import {
 import { route } from '$lib/ROUTES';
 import { error } from '@sveltejs/kit';
 import { Feed } from 'feed';
-import { joinURL } from 'ufo';
 
 const DOMAIN = route('domain');
 
@@ -27,8 +26,8 @@ export const GET = (async () => {
 		id: domain,
 		link: domain,
 		language: 'en',
-		image: joinURL(domain, 'favicon.png'),
-		favicon: joinURL(domain, 'favicon.png'),
+		image: new URL('favicon.png', domain).toString(),
+		favicon: new URL('favicon.png', domain).toString(),
 		copyright: `MIT 2024 © ${user.name}`,
 		feedLinks: {
 			rss: `${domain}/rss.xml`,


### PR DESCRIPTION
## Summary

- Replaced all occurrences of `ufo.joinURL()` with the native JavaScript `new URL().toString()` API
- Removed the `ufo` package dependency from the project
- This reduces bundle size and uses standard web APIs instead of external dependencies

## Changes Made

- **src/routes/Header.svelte**: Replaced `joinURL("https://github.com", user.username)` with `new URL(user.username, "https://github.com/").toString()`
- **src/routes/Meta.svelte**: Replaced `joinURL("https://github.com", user.username)` with `new URL(user.username, "https://github.com/").toString()`
- **src/routes/PullRequest.svelte**: Replaced `joinURL("https://github.com", pr.repo)` with `new URL(pr.repo, "https://github.com/").toString()`
- **src/routes/feed.xml/+server.ts**: Replaced `joinURL(domain, "favicon.png")` with `new URL("favicon.png", domain).toString()`
- **package.json**: Removed `ufo` dependency

## Test Plan

- [x] All TypeScript types check correctly (`pnpm check` passes)
- [x] No linting errors (`pnpm lint` passes)
- [x] Code is properly formatted (`pnpm format` applied)
- [ ] Manually test that all URLs are generated correctly in development
- [ ] Verify GitHub profile links work correctly
- [ ] Verify RSS feed generates with correct favicon URLs